### PR TITLE
Using new Buffer() instead of just Buffer()

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function encode(channelData, opts) {
   u32(buffer.byteLength - 44);
   lookup(data_encoders, bitDepth, floatingPoint)(buffer, pos, channelData, channels, samples);
 
-  return Buffer(buffer);
+  return new Buffer(buffer);
 }
 
 module.exports = {


### PR DESCRIPTION
From Node 7 onwards you get this message:

DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.

Should probably be Buffer.from() but it's only available from Node 5, if that's important.